### PR TITLE
Fix env var in feature flag layer

### DIFF
--- a/backend/src/FeatureFlagLayer/getConfig.js
+++ b/backend/src/FeatureFlagLayer/getConfig.js
@@ -2,11 +2,8 @@
 const fetch = require('node-fetch');
 
 async function getConfig() {
-  let appconfigPort = 2772;
+  const appconfigPort = process.env.AWS_APPCONFIG_EXTENSION_HTTP_PORT || 2772;
   try {
-    if (process.env.AWS_APPCONFIG_EXTENSION_HTTP_PORT) {
-      appconfigPort = process.env.APPCONFIG_EXTENSION_HTTP_PORT;
-    }
     const url = `http://localhost:${appconfigPort}`
               + `/applications/${process.env.APPCONFIG_APPLICATION}`
               + `/environments/${process.env.APPCONFIG_ENVIRONMENT}`


### PR DESCRIPTION
Fix AppConfig extension HTTP port environment variable in feature flag layer and simplify condition

*Issue:* `APPCONFIG_EXTENSION_HTTP_PORT` env variable is a typo. Good variable name is `
AWS_APPCONFIG_EXTENSION_HTTP_PORT`

*Description of changes:* Fix typo and simplify condition


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
